### PR TITLE
Fix global state initialization and import paths

### DIFF
--- a/js/core/core.state.js
+++ b/js/core/core.state.js
@@ -210,4 +210,16 @@ const stateManager = {
     bus: eventBus
 };
 
+// Expose important constants and the state manager on the global object so
+// other modules that rely on global variables can access them without explicit
+// imports. This mirrors the previous non-module behaviour of the app.
+window.DB_NAME_PREFIX = DB_NAME_PREFIX;
+window.SESSIONS_STORE_NAME = SESSIONS_STORE_NAME;
+window.METADATA_STORE_NAME = METADATA_STORE_NAME;
+window.METADATA_KEY = METADATA_KEY;
+window.ALL_AGENT_SETTINGS_IDS = ALL_AGENT_SETTINGS_IDS;
+window.defaultAgentSettings = defaultAgentSettings;
+window.defaultSystemUtilityAgent = defaultSystemUtilityAgent;
+window.defaultSummarizationPresets = defaultSummarizationPresets;
+window.defaultMemories = defaultMemories;
 window.stateManager = stateManager;

--- a/src/main.js
+++ b/src/main.js
@@ -5,19 +5,21 @@
 
 // 1. Import the entire CSS structure
 import './styles/main.css';
+// Ensure core state and global constants are initialised
+import '../js/core/core.state.js';
 
 // 2. Import necessary functions from all other modules
 // Note: You must add 'export' to these functions in their original files.
-import { openDb, dbRequest } from './js/core/core.db.js';
-import { loadAllProviderModels } from './js/core/core.api.js';
-import { initCoreUI } from './js/core/core.ui.js';
-import { initProjectUI } from './js/modules/project/project.ui.js';
-import { loadProjectData, proceedWithCreatingNewProject } from './js/modules/project/project.handlers.js';
-import { initSessionUI } from './js/modules/session/session.ui.js';
-import { initAgentUI } from './js/modules/agent/agent.ui.js';
-import { initGroupUI } from './js/modules/group/group.ui.js';
-import { initMemoryUI } from './js/modules/memory/memory.ui.js';
-import { initChatUI, showCustomAlert } from './js/modules/chat/chat.ui.js'; // Assuming showCustomAlert is in chat.ui.js
+import { openDb, dbRequest } from '../js/core/core.db.js';
+import { loadAllProviderModels } from '../js/core/core.api.js';
+import { initCoreUI } from '../js/core/core.ui.js';
+import { initProjectUI } from '../js/modules/project/project.ui.js';
+import { loadProjectData, proceedWithCreatingNewProject } from '../js/modules/project/project.handlers.js';
+import { initSessionUI } from '../js/modules/session/session.ui.js';
+import { initAgentUI } from '../js/modules/agent/agent.ui.js';
+import { initGroupUI } from '../js/modules/group/group.ui.js';
+import { initMemoryUI } from '../js/modules/memory/memory.ui.js';
+import { initChatUI, showCustomAlert } from '../js/modules/chat/chat.ui.js'; // Assuming showCustomAlert is in chat.ui.js
 
 /**
  * ฟังก์ชันหลักในการเริ่มต้นการทำงานของแอปพลิเคชันทั้งหมด


### PR DESCRIPTION
## Summary
- expose DB constants and defaults on `window` in `core.state.js`
- load `core.state.js` in `src/main.js`
- correct module import paths in `src/main.js`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0139f778832f8d8d721b12cf7048