### PR TITLE
Fix import paths for main module

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,16 +8,16 @@ import './styles/main.css';
 
 // 2. Import necessary functions from all other modules
 // Note: You must add 'export' to these functions in their original files.
-import { openDb, dbRequest } from './js/core/core.db.js';
-import { loadAllProviderModels } from './js/core/core.api.js';
-import { initCoreUI } from './js/core/core.ui.js';
-import { initProjectUI } from './js/modules/project/project.ui.js';
-import { loadProjectData, proceedWithCreatingNewProject } from './js/modules/project/project.handlers.js';
-import { initSessionUI } from './js/modules/session/session.ui.js';
-import { initAgentUI } from './js/modules/agent/agent.ui.js';
-import { initGroupUI } from './js/modules/group/group.ui.js';
-import { initMemoryUI } from './js/modules/memory/memory.ui.js';
-import { initChatUI, showCustomAlert } from './js/modules/chat/chat.ui.js'; // Assuming showCustomAlert is in chat.ui.js
+import { openDb, dbRequest } from '../js/core/core.db.js';
+import { loadAllProviderModels } from '../js/core/core.api.js';
+import { initCoreUI } from '../js/core/core.ui.js';
+import { initProjectUI } from '../js/modules/project/project.ui.js';
+import { loadProjectData, proceedWithCreatingNewProject } from '../js/modules/project/project.handlers.js';
+import { initSessionUI } from '../js/modules/session/session.ui.js';
+import { initAgentUI } from '../js/modules/agent/agent.ui.js';
+import { initGroupUI } from '../js/modules/group/group.ui.js';
+import { initMemoryUI } from '../js/modules/memory/memory.ui.js';
+import { initChatUI, showCustomAlert } from '../js/modules/chat/chat.ui.js'; // Assuming showCustomAlert is in chat.ui.js
 
 /**
  * ฟังก์ชันหลักในการเริ่มต้นการทำงานของแอปพลิเคชันทั้งหมด


### PR DESCRIPTION
## Summary
- fix relative import paths after moving `main.js` under `src`

## Testing
- `npm run build` *(fails: showCustomAlert not exported)*

------
https://chatgpt.com/codex/tasks/task_e_685e037a6c5c832fac75c73f0f3359dc